### PR TITLE
Remove X-Forwarded-Host header

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -105,6 +105,7 @@ server {
     proxy_set_header  X-Forwarded-Proto $scheme;
     proxy_set_header  X-Real-IP  $remote_addr;
     proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header  X-Forwarded-Host "";
     proxy_set_header  Host $http_host;
     proxy_redirect off;
     if (-f $request_filename) {


### PR DESCRIPTION
This can cause security issues and generally isn't actually used anyway.
