### PR TITLE
Unset X-Forwarded-Host for http also

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -40,6 +40,7 @@ server {
         proxy_set_header  X-Forwarded-Proto <%= @forwarded_protocol %>;
         proxy_set_header  X-Real-IP  $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Host "";
         proxy_set_header  Host $http_host;
       <% end %>
 


### PR DESCRIPTION
We unset this for https but we also need to unset for http. Mainly because the portal hosts that are behind ELB are using http in their nginx configs.

https://jira.common.bluescape.com/browse/CO-2335
