### PR TITLE
Fix error pages

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -25,10 +25,10 @@ server {
     error_log   <%= @app_root %>/shared/log/error.log;
 
     if (-f $document_root/system/maintenance.html) {
-      return 503;
+      return 555;
     }
 
-    error_page 503 @maintenance;
+    error_page 555 =503 @maintenance;
     location @maintenance {
       rewrite  ^(.*)$  /system/maintenance.html last;
       break;
@@ -93,10 +93,10 @@ server {
   error_log   <%= @app_root %>/shared/log/error.log;
 
   if (-f $document_root/system/maintenance.html) {
-    return 503;
+    return 555;
   }
 
-  error_page 503 @maintenance;
+  error_page 555 =503 @maintenance;
   location @maintenance {
     rewrite  ^(.*)$  /system/maintenance.html last;
     break;

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -34,6 +34,8 @@ server {
       break;
     }
 
+    error_page  500 502 503 504 /500;
+    error_page  404 /404;
 
     location / {
       <% if @include_forwarding_headers %>
@@ -55,17 +57,6 @@ server {
          break;
        }
      }
-
-    error_page  500 502 503 504 /500.html;
-    error_page  404 /404.html;
-
-    location = /500.html {
-      root  <%= @app_root %>/current/public;
-    }
-
-    location = /400.html {
-      root  <%= @app_root %>/current/public;
-    }
 
     <% if @asset_location && @asset_root %>
     location ^~ <%= @asset_location %> {
@@ -102,6 +93,9 @@ server {
     break;
   }
 
+  error_page  500 502 503 504 /500;
+  error_page  404 /404;
+
   location / {
     proxy_set_header  X-Forwarded-Proto $scheme;
     proxy_set_header  X-Real-IP  $remote_addr;
@@ -118,17 +112,6 @@ server {
        break;
      }
    }
-
-  error_page  500 502 503 504 /500.html;
-  error_page  404 /404.html;
-
-  location = /500.html {
-    root  <%= @app_root %>/current/public;
-  }
-
-  location = /400.html {
-    root  <%= @app_root %>/current/public;
-  }
 
   <% if @asset_location && @asset_root %>
   location ^~ <%= @asset_location %> {


### PR DESCRIPTION
Right now, maintenance mode adds a error_page handler for 503 responses. Unfortunately, this overrides the standard 503 response handler. This pull request makes maintenance mode internally use status code 555 to avoid conflict. Additionally, it fixes the URLs for the error page handlers.